### PR TITLE
Stop running upload on push to main

### DIFF
--- a/.github/workflows/upload-legacy-ami.yml
+++ b/.github/workflows/upload-legacy-ami.yml
@@ -2,9 +2,6 @@ name: Upload Legacy Amazon Image
 permissions:
   contents: read
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
We want to keep the weekly cadence. Not upload again for every change to main. We can always trigger the workflow manually if needed