### PR TITLE
upload-legacy-ami: switch from small channel to big one

### DIFF
--- a/.github/workflows/upload-legacy-ami.yml
+++ b/.github/workflows/upload-legacy-ami.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         release:
-          - release-24.05-small
+          - release-24.05
           # - nixos-unstable
         system:
           - x86_64-linux


### PR DESCRIPTION
We'd like to slim the -small channels by avoiding these images.