### PR TITLE
Format upload-ami code

### DIFF
--- a/upload-ami/src/upload_ami/upload_ami.py
+++ b/upload-ami/src/upload_ami/upload_ami.py
@@ -265,7 +265,9 @@ def copy_image_to_regions(
             "%Y-%m-%dT%H:%M:%SZ"
         )
         logging.info(f"Deprecating {copy_image['ImageId']} at {deprecate_at}")
-        ec2r.enable_image_deprecation(ImageId=copy_image['ImageId'], DeprecateAt=deprecate_at)
+        ec2r.enable_image_deprecation(
+            ImageId=copy_image["ImageId"], DeprecateAt=deprecate_at
+        )
         if public:
             logging.info(f"Making {copy_image['ImageId']} public")
             ec2r.modify_image_attribute(


### PR DESCRIPTION
Ran into the following.

```console
$ nix run github:NixOS/amis#upload-ami -- --s3-bucket some-ecs-ami --image-info "$(nix build .#.nixosConfigurations.default.config.system.build.amazonImage)"
       > wrapping `/nix/store/fm6v06r1vklw9a4c8sh0fxr73jwzz3qp-upload-ami-0.1.0/bin/nuke'...
       > Executing pythonRemoveTestsDir
       > Finished executing pythonRemoveTestsDir
       > Running phase: installCheckPhase
       > Success: no issues found in 8 source files(B
       > would reformat /private/tmp/nix-build-upload-ami-0.1.0.drv-0/upload-ami/src/upload_ami/upload_ami.py
       >
       > Oh no! 💥 💔 💥
       > 1 file would be reformatted, 7 files would be left unchanged.
       For full logs, run 'nix log /nix/store/962jvz0xnng7p0r708bsywxihz89a63v-upload-ami-0.1.0.drv'.
```