### PR TITLE
Try `ubuntu-24.04-arm` instead of `ubuntu-latest-arm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,8 @@ jobs:
         runs-on:
           - labels: [ubuntu-latest]
             system: x86_64-linux
-          # TODO: Seems github ran out of capacity. they're queuing forever
-          # - labels: [ubuntu-latest-arm]
-          #   system: aarch64-linux
+          - labels: [ubuntu-24.04-arm]
+            system: aarch64-linux
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - uses: DeterminateSystems/nix-installer-action@7993355175c2765e5733dae74f3e0786fe0e5c4f # v12


### PR DESCRIPTION
`ubuntu-latest-arm` was queueing forever https://github.com/NixOS/amis/actions/runs/13317529564/job/37195954892

but https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

doesn't mention this existing. so maybe i need to fix the typo