### PR TITLE
Use alternative way of referencing python packages compatible with NixOS 25.05 and beyond

### DIFF
--- a/upload-ami/default.nix
+++ b/upload-ami/default.nix
@@ -1,8 +1,10 @@
 {
   buildPythonApplication,
-  python3Packages,
+  python,
   awscli2,
   opentofu,
+  mypy,
+  black,
   lib,
 }:
 
@@ -28,7 +30,7 @@ let
     dep:
     let
       inherit (parseDependency dep) name extras;
-      package = python3Packages.${name};
+      package = python.pkgs.${name};
       optionalPackages = lib.flatten (map (name: package.optional-dependencies.${name}) extras);
     in
     [ package ] ++ optionalPackages;
@@ -39,11 +41,11 @@ buildPythonApplication {
   version = pyproject.project.version;
   src = ./.;
   pyproject = true;
-  nativeBuildInputs = map (name: python3Packages.${name}) pyproject.build-system.requires ++ [
+  nativeBuildInputs = map (name: python.pkgs.${name}) pyproject.build-system.requires ++ [
     opentofu
     awscli2
-    python3Packages.mypy
-    python3Packages.black
+    mypy
+    black
   ];
 
   propagatedBuildInputs = lib.flatten (map resolvePackages pyproject.project.dependencies);


### PR DESCRIPTION
I tried to use the `update-ami` utility with versions of NixOS newer than 24.11, and hit errors when running `nix build .#update-ami`.

I think this PR fixes the problem. However, I am not really a nix, python packaging, or AMI expert, so there could easily be some unexpected side effects. I did some basic testing, and with my changes `update-ami` now builds with NixOS 24.11, 25.05, and unstable (as of Aug 3, 2025), and I was able to successfully upload a usable AMI using it.

I have not done extensive testing, as it is not obvious to me what kind you (the maintainers) might want to see before accepting a PR.