### PR TITLE
Fix build after changes to buildPythonApplication

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
             program = "${upload-ami}/bin/${name}";
           };
         in
-        mapAttrs mkApp self.packages.${system}.upload-ami.passthru.pyproject.project.scripts
+        mapAttrs mkApp self.packages.${system}.upload-ami.passthru.upload-ami.pyproject.project.scripts
       );
 
       formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);

--- a/upload-ami/default.nix
+++ b/upload-ami/default.nix
@@ -48,7 +48,7 @@ let
         pyproject = true;
         nativeBuildInputs = lib.flatten (map resolvePkgs requires);
         propagatedBuildInputs = lib.flatten (map resolvePkgs dependencies);
-        passthru.pyproject = pyproject;
+        passthru.upload-ami.pyproject = pyproject;
       }
     ) args;
 


### PR DESCRIPTION
Fixes the build after the latest renovate, caused by nixpkgs [PR376372](https://github.com/NixOS/nixpkgs/pull/376372).

Not too sure if this is exactly how you'd want to fix it, but figured I'd send the PR anyway since I fixed it for my own purposes.