### PR TITLE
site: Update the example to point to 25.11 release

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -228,7 +228,7 @@ data "aws_ami" "nixos_arm64" {
 
   filter {
     name   = "name"
-    values = ["nixos/24.11*"]
+    values = ["nixos/25.11.*"]
   }
   filter {
     name   = "architecture"


### PR DESCRIPTION
Also changes the regex to search specifically for newer AMIs from a reelase

`25.11*` to `25.11.*`

With 24.11 being garbage collected, just copy pasting the example was failing for me.
