### PR TITLE
Add --best-effort-region to delete-deprecated-images

### DIFF
--- a/.github/workflows/upload-legacy-ami.yml
+++ b/.github/workflows/upload-legacy-ami.yml
@@ -101,7 +101,10 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - name: Delete deprecated AMIs
         if: github.ref == 'refs/heads/main'
-        run: "nix run .#delete-deprecated-images \n"
+        run: |
+          nix run .#delete-deprecated-images -- \
+            --best-effort-region me-central-1 \
+            --best-effort-region me-south-1
   deploy-pages:
     name: Deploy images page
     if: github.ref == 'refs/heads/main'

--- a/upload-ami/src/upload_ami/delete_deprecated_images.py
+++ b/upload-ami/src/upload_ami/delete_deprecated_images.py
@@ -78,6 +78,12 @@ def main() -> None:
         metavar="DAYS",
         help="Number of days after deprecation before an image is deleted (default: 0)",
     )
+    parser.add_argument(
+        "--best-effort-region",
+        help="Regions where failures are logged as warnings instead of errors",
+        action="append",
+        default=[],
+    )
     logging.basicConfig(level=logging.INFO)
     ec2: EC2Client = boto3.client("ec2")
 
@@ -85,9 +91,17 @@ def main() -> None:
     regions = ec2.describe_regions()["Regions"]
     for region in regions:
         assert "RegionName" in region
-        ec2r = boto3.client("ec2", region_name=region["RegionName"])
-        logging.info(f"Checking region {region['RegionName']}")
-        delete_deprecated_images(ec2r, args.dry_run, args.grace_period)
+        region_name = region["RegionName"]
+        ec2r = boto3.client("ec2", region_name=region_name)
+        logging.info(f"Checking region {region_name}")
+        try:
+            delete_deprecated_images(ec2r, args.dry_run, args.grace_period)
+        except Exception as e:
+            if region_name not in args.best_effort_region:
+                raise
+            logging.warning(
+                f"Deleting deprecated images in {region_name} failed (best-effort, ignoring): {e}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Region outages (e.g. me-south-1 timeout) cause the entire deprecation job to fail. Apply the same --best-effort-region pattern already used by upload-ami so that disrupted regions are logged as warnings instead of aborting the run.