### PR TITLE
Replace S3 snapshot import with EBS Direct API uploads

### DIFF
--- a/.github/workflows/upload-ami.yml
+++ b/.github/workflows/upload-ami.yml
@@ -1,4 +1,4 @@
-name: Upload Legacy Amazon Image
+name: Upload Amazon Image
 permissions:
   contents: read
 on:
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * 0"
 jobs:
   upload-ami:
-    name: Upload Legacy Amazon Image
+    name: Upload Amazon Image
     runs-on: ubuntu-latest
     environment: images
     permissions:
@@ -46,11 +46,9 @@ jobs:
         id: upload_smoke_test_ami
         run: |
           image_info='${{ steps.download_ami.outputs.image_info }}'
-          images_bucket='${{ vars.IMAGES_BUCKET }}'
           image_ids=$(nix run .#upload-ami -- \
             --image-info "$image_info" \
-            --prefix "smoketest/" \
-            --s3-bucket "$images_bucket")
+            --prefix "smoketest/")
           echo "image_ids=$image_ids" >> "$GITHUB_OUTPUT"
       - name: Smoke test
         id: smoke_test
@@ -73,11 +71,9 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           image_info='${{ steps.download_ami.outputs.image_info }}'
-          images_bucket='${{ vars.IMAGES_BUCKET }}'
           nix run .#upload-ami -- \
             --image-info "$image_info" \
             --prefix "nixos/" \
-            --s3-bucket "$images_bucket" \
             --copy-to-regions \
             --best-effort-region me-central-1 \
             --best-effort-region me-south-1 \

--- a/tf/iam_github_actions.tf
+++ b/tf/iam_github_actions.tf
@@ -6,17 +6,9 @@ data "aws_iam_policy_document" "upload_ami" {
   statement {
     effect = "Allow"
     actions = [
-      "s3:GetObject",
-      "s3:PutObject",
-      "s3:DeleteObject",
-    ]
-    resources = ["${aws_s3_bucket.images.arn}/*"]
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "ec2:ImportSnapshot",
-      "ec2:DescribeImportSnapshotTasks",
+      "ebs:StartSnapshot",
+      "ebs:PutSnapshotBlock",
+      "ebs:CompleteSnapshot",
       "ec2:DescribeSnapshots",
       "ec2:DeleteSnapshot",
     ]
@@ -28,7 +20,6 @@ data "aws_iam_policy_document" "upload_ami" {
     resources = [
       "arn:aws:ec2:*:*:snapshot/*",
       "arn:aws:ec2:*:*:image/*",
-      "arn:aws:ec2:*:*:import-snapshot-task/*",
     ]
   }
   statement {

--- a/upload-ami/pyproject.toml
+++ b/upload-ami/pyproject.toml
@@ -6,7 +6,7 @@ name = "upload-ami"
 version = "0.1.0"
 dependencies = [
     "boto3",
-    "boto3-stubs[ec2,s3,sts,account,service-quotas]",
+    "boto3-stubs[ebs,ec2,sts,account,service-quotas]",
     "botocore-stubs",
 ]
 [project.scripts]

--- a/upload-ami/src/upload_ami/snapshot_uploader.py
+++ b/upload-ami/src/upload_ami/snapshot_uploader.py
@@ -1,7 +1,7 @@
 """Upload raw disk images to EBS snapshots via EBS Direct APIs.
 
-Uses PutSnapshotBlock to write 512 KiB blocks in parallel.  Transient
-errors are retried with full-jitter exponential backoff.
+Uses PutSnapshotBlock to write 512 KiB blocks in parallel.  Retries
+are handled by boto3's adaptive retry mode.
 """
 
 import base64
@@ -9,7 +9,6 @@ import hashlib
 import logging
 import math
 import os
-import random
 import threading
 import time
 import uuid
@@ -18,22 +17,12 @@ from pathlib import Path
 
 import boto3
 import botocore.config
-import botocore.exceptions
 from mypy_boto3_ebs.client import EBSClient
 
 log = logging.getLogger(__name__)
 
 BLOCK_SIZE = 512 * 1024  # Fixed by EBS Direct API.
 GIB = 1024**3
-
-# Error codes that indicate throttling (retryable).
-_THROTTLE_CODES = frozenset(
-    {
-        "RequestThrottledException",
-        "ThrottlingException",
-        "Throttling",
-    }
-)
 
 
 def upload_snapshot(
@@ -45,7 +34,6 @@ def upload_snapshot(
     tags: dict[str, str] | None = None,
     client_token: str | None = None,
     workers: int = 64,
-    block_attempts: int = 5,
     timeout_minutes: int = 60,
 ) -> str:
     """Upload a raw disk image to a new EBS snapshot.
@@ -95,7 +83,6 @@ def upload_snapshot(
             file_size,
             client,
             workers,
-            block_attempts,
         )
         status = _complete_snapshot(client, snapshot_id, block_count)
         if status == "error":
@@ -118,9 +105,9 @@ def upload_snapshot(
 
 
 def _create_client(region: str, max_connections: int) -> EBSClient:
-    """Create a boto3 EBS client with a connection pool sized for the worker count."""
+    """Create a boto3 EBS client with adaptive retry and a sized connection pool."""
     cfg = botocore.config.Config(
-        retries={"mode": "standard", "total_max_attempts": 1},
+        retries={"mode": "adaptive"},
         connect_timeout=5,
         read_timeout=12,
         max_pool_connections=max_connections,
@@ -160,34 +147,17 @@ def _start_snapshot(
 
 
 def _complete_snapshot(
-    client: EBSClient, snapshot_id: str, block_count: int, attempts: int = 5
+    client: EBSClient, snapshot_id: str, block_count: int
 ) -> str:
-    """Complete the snapshot, retrying on transient errors.
+    """Complete the snapshot.
 
     Returns the snapshot status from the CompleteSnapshot response.
+    Retries are handled by boto3's adaptive retry mode.
     """
-    last_exc: Exception | None = None
-    for attempt in range(attempts):
-        if attempt > 0:
-            time.sleep(_backoff_s(attempt))
-        try:
-            resp = client.complete_snapshot(
-                SnapshotId=snapshot_id, ChangedBlocksCount=block_count
-            )
-            return resp["Status"]
-        except Exception as exc:
-            if not _is_retryable(exc):
-                raise
-            last_exc = exc
-            log.warning(
-                "CompleteSnapshot attempt %d/%d failed: %s",
-                attempt + 1,
-                attempts,
-                exc,
-            )
-    raise RuntimeError(
-        f"CompleteSnapshot failed after {attempts} attempts: {last_exc}"
+    resp = client.complete_snapshot(
+        SnapshotId=snapshot_id, ChangedBlocksCount=block_count
     )
+    return resp["Status"]
 
 
 def _put_block(
@@ -258,39 +228,6 @@ def _read_block(fd: int, block_index: int, file_size: int) -> bytes:
     return data
 
 
-# -- Retry logic -------------------------------------------------------------
-
-
-def _is_retryable(exc: Exception) -> bool:
-    """Return True if the error is transient and worth retrying.
-
-    Retries transport errors, throttling codes, and any server-side 5xx.
-    """
-    if isinstance(
-        exc,
-        (
-            botocore.exceptions.ReadTimeoutError,
-            botocore.exceptions.ConnectTimeoutError,
-            botocore.exceptions.EndpointConnectionError,
-            botocore.exceptions.ConnectionClosedError,
-        ),
-    ):
-        return True
-    if isinstance(exc, botocore.exceptions.ClientError):
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code in _THROTTLE_CODES:
-            return True
-        http_status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
-        return http_status >= 500
-    return False
-
-
-def _backoff_s(attempt: int) -> float:
-    """Full-jitter exponential backoff capped at 2 seconds."""
-    ceiling: float = min(2.0, 0.1 * (2**attempt))
-    return random.random() * ceiling
-
-
 # -- Upload orchestration ----------------------------------------------------
 
 
@@ -301,9 +238,8 @@ def _upload_blocks(
     file_size: int,
     client: EBSClient,
     workers: int,
-    block_attempts: int,
 ) -> None:
-    """Upload all blocks in parallel with per-block retries."""
+    """Upload all blocks in parallel. Retries are handled by boto3."""
     fd = os.open(str(path), os.O_RDONLY)
     try:
         failed: dict[int, BaseException] = {}
@@ -322,7 +258,6 @@ def _upload_blocks(
                     idx,
                     file_size,
                     client,
-                    block_attempts,
                 )
                 futures[f] = idx
 
@@ -348,40 +283,7 @@ def _upload_one_block(
     block_index: int,
     file_size: int,
     client: EBSClient,
-    block_attempts: int,
 ) -> None:
-    """Upload a single block with retries and exponential backoff."""
+    """Upload a single block. Retries are handled by boto3."""
     data = _read_block(fd, block_index, file_size)
-
-    last_exc: Exception | None = None
-    for attempt in range(block_attempts):
-        if attempt > 0:
-            delay = _backoff_s(attempt)
-            log.debug(
-                "block %d: retry %d/%d, backoff %.0fms",
-                block_index,
-                attempt,
-                block_attempts,
-                delay * 1000,
-            )
-            time.sleep(delay)
-        try:
-            _put_block(client, snapshot_id, block_index, data)
-            return
-        except Exception as exc:
-            if not _is_retryable(exc):
-                raise RuntimeError(
-                    f"block {block_index}: permanent failure: {exc}"
-                ) from exc
-            last_exc = exc
-            log.warning(
-                "block %d: attempt %d/%d failed: %s",
-                block_index,
-                attempt + 1,
-                block_attempts,
-                exc,
-            )
-
-    raise RuntimeError(
-        f"block {block_index}: failed after {block_attempts} attempts: {last_exc}"
-    )
+    _put_block(client, snapshot_id, block_index, data)

--- a/upload-ami/src/upload_ami/snapshot_uploader.py
+++ b/upload-ami/src/upload_ami/snapshot_uploader.py
@@ -1,0 +1,387 @@
+"""Upload raw disk images to EBS snapshots via EBS Direct APIs.
+
+Uses PutSnapshotBlock to write 512 KiB blocks in parallel.  Transient
+errors are retried with full-jitter exponential backoff.
+"""
+
+import base64
+import hashlib
+import logging
+import math
+import os
+import random
+import threading
+import time
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import boto3
+import botocore.config
+import botocore.exceptions
+from mypy_boto3_ebs.client import EBSClient
+
+log = logging.getLogger(__name__)
+
+BLOCK_SIZE = 512 * 1024  # Fixed by EBS Direct API.
+GIB = 1024**3
+
+# Error codes that indicate throttling (retryable).
+_THROTTLE_CODES = frozenset(
+    {
+        "RequestThrottledException",
+        "ThrottlingException",
+        "Throttling",
+    }
+)
+
+
+def upload_snapshot(
+    path: str | Path,
+    *,
+    region: str,
+    volume_size_gib: int | None = None,
+    description: str | None = None,
+    tags: dict[str, str] | None = None,
+    client_token: str | None = None,
+    workers: int = 64,
+    block_attempts: int = 5,
+    timeout_minutes: int = 60,
+) -> str:
+    """Upload a raw disk image to a new EBS snapshot.
+
+    Returns the snapshot ID on success.  On failure the incomplete
+    snapshot is deleted and the exception is re-raised.
+
+    If *client_token* is provided and a snapshot with that token already
+    exists in completed state, returns immediately (idempotent retry).
+    If *tags* are provided they are set atomically at snapshot creation.
+    """
+    file_path = Path(path)
+    file_size = file_path.stat().st_size
+    block_count = math.ceil(file_size / BLOCK_SIZE)
+    if volume_size_gib is None:
+        volume_size_gib = max(math.ceil(file_size / GIB), 1)
+
+    client = _create_client(region, workers)
+    t0 = time.monotonic()
+
+    snapshot_id, status = _start_snapshot(
+        client, volume_size_gib, description, timeout_minutes, tags, client_token
+    )
+
+    if status == "completed":
+        log.info("Snapshot %s already completed (idempotent)", snapshot_id)
+        return snapshot_id
+
+    if status != "pending":
+        raise RuntimeError(
+            f"StartSnapshot returned unexpected status {status!r} for {snapshot_id}"
+        )
+
+    log.info(
+        "Started %s: %d blocks, %d GiB, %d workers",
+        snapshot_id,
+        block_count,
+        volume_size_gib,
+        workers,
+    )
+
+    try:
+        _upload_blocks(
+            file_path,
+            snapshot_id,
+            block_count,
+            file_size,
+            client,
+            workers,
+            block_attempts,
+        )
+        status = _complete_snapshot(client, snapshot_id, block_count)
+        if status == "error":
+            raise RuntimeError(f"CompleteSnapshot returned error for {snapshot_id}")
+        if status != "completed":
+            _wait_for_snapshot(region, snapshot_id)
+    except Exception:
+        elapsed = time.monotonic() - t0
+        log.error("Upload failed after %.1fs for %s", elapsed, snapshot_id)
+        _cleanup_snapshot(region, snapshot_id)
+        raise
+
+    elapsed = time.monotonic() - t0
+    throughput = (file_size / (1024 * 1024)) / elapsed if elapsed > 0 else 0.0
+    log.info("Completed %s: %.1fs, %.1f MiB/s", snapshot_id, elapsed, throughput)
+    return snapshot_id
+
+
+# -- Client creation ---------------------------------------------------------
+
+
+def _create_client(region: str, max_connections: int) -> EBSClient:
+    """Create a boto3 EBS client with a connection pool sized for the worker count."""
+    cfg = botocore.config.Config(
+        retries={"mode": "standard", "total_max_attempts": 1},
+        connect_timeout=5,
+        read_timeout=12,
+        max_pool_connections=max_connections,
+        tcp_keepalive=True,
+    )
+    return boto3.client("ebs", region_name=region, config=cfg)
+
+
+# -- EBS Direct API wrappers ------------------------------------------------
+
+
+def _start_snapshot(
+    client: EBSClient,
+    volume_size_gib: int,
+    description: str | None,
+    timeout_minutes: int,
+    tags: dict[str, str] | None,
+    client_token: str | None,
+) -> tuple[str, str]:
+    """Start a snapshot, returning (snapshot_id, status).
+
+    Status is 'pending' for new snapshots, 'completed' for idempotent
+    retries where the snapshot already finished.
+    """
+    token = client_token or str(uuid.uuid4())
+    kwargs: dict[str, object] = {
+        "VolumeSize": volume_size_gib,
+        "Timeout": timeout_minutes,
+        "ClientToken": token,
+    }
+    if description is not None:
+        kwargs["Description"] = description
+    if tags:
+        kwargs["Tags"] = [{"Key": k, "Value": v} for k, v in tags.items()]
+    resp = client.start_snapshot(**kwargs)  # type: ignore[arg-type]
+    return resp["SnapshotId"], resp["Status"]
+
+
+def _complete_snapshot(
+    client: EBSClient, snapshot_id: str, block_count: int, attempts: int = 5
+) -> str:
+    """Complete the snapshot, retrying on transient errors.
+
+    Returns the snapshot status from the CompleteSnapshot response.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(attempts):
+        if attempt > 0:
+            time.sleep(_backoff_s(attempt))
+        try:
+            resp = client.complete_snapshot(
+                SnapshotId=snapshot_id, ChangedBlocksCount=block_count
+            )
+            return resp["Status"]
+        except Exception as exc:
+            if not _is_retryable(exc):
+                raise
+            last_exc = exc
+            log.warning(
+                "CompleteSnapshot attempt %d/%d failed: %s",
+                attempt + 1,
+                attempts,
+                exc,
+            )
+    raise RuntimeError(
+        f"CompleteSnapshot failed after {attempts} attempts: {last_exc}"
+    )
+
+
+def _put_block(
+    client: EBSClient, snapshot_id: str, block_index: int, data: bytes
+) -> None:
+    checksum = base64.b64encode(hashlib.sha256(data).digest()).decode("ascii")
+    client.put_snapshot_block(
+        SnapshotId=snapshot_id,
+        BlockIndex=block_index,
+        BlockData=data,
+        DataLength=len(data),
+        Checksum=checksum,
+        ChecksumAlgorithm="SHA256",
+    )
+
+
+def _cleanup_snapshot(region: str, snapshot_id: str) -> None:
+    """Check snapshot state and clean up if appropriate.
+
+    If the snapshot reached 'completed' despite the error (e.g. waiter
+    timeout on a slow finalization), log a warning but do not delete it.
+    If it is in 'error' or still 'pending', delete it.
+    """
+    try:
+        ec2 = boto3.client("ec2", region_name=region)
+        resp = ec2.describe_snapshots(SnapshotIds=[snapshot_id])
+        if resp["Snapshots"]:
+            state = resp["Snapshots"][0].get("State", "")
+            if state == "completed":
+                log.warning(
+                    "Snapshot %s is completed despite error; not deleting",
+                    snapshot_id,
+                )
+                return
+            log.info("Snapshot %s in state %r, deleting", snapshot_id, state)
+        ec2.delete_snapshot(SnapshotId=snapshot_id)
+    except Exception as exc:
+        log.warning("Failed to clean up %s: %s", snapshot_id, exc)
+
+
+def _wait_for_snapshot(region: str, snapshot_id: str) -> None:
+    """Wait for the snapshot to reach 'completed' state in EC2.
+
+    CompleteSnapshot starts an async workflow; the EC2 snapshot may still
+    be 'pending' briefly.  Poll every 2 seconds for up to 60 seconds.
+    """
+    ec2 = boto3.client("ec2", region_name=region)
+    ec2.get_waiter("snapshot_completed").wait(
+        SnapshotIds=[snapshot_id],
+        WaiterConfig={"Delay": 2, "MaxAttempts": 30},
+    )
+
+
+# -- Block I/O --------------------------------------------------------------
+
+
+def _read_block(fd: int, block_index: int, file_size: int) -> bytes:
+    """Read one 512 KiB block via pread, zero-padding the last block."""
+    offset = block_index * BLOCK_SIZE
+    to_read = min(BLOCK_SIZE, file_size - offset)
+    data = os.pread(fd, to_read, offset)
+    if len(data) < to_read:
+        raise OSError(
+            f"Short read at block {block_index}: expected {to_read}, got {len(data)}"
+        )
+    if len(data) < BLOCK_SIZE:
+        data += b"\x00" * (BLOCK_SIZE - len(data))
+    return data
+
+
+# -- Retry logic -------------------------------------------------------------
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """Return True if the error is transient and worth retrying.
+
+    Retries transport errors, throttling codes, and any server-side 5xx.
+    """
+    if isinstance(
+        exc,
+        (
+            botocore.exceptions.ReadTimeoutError,
+            botocore.exceptions.ConnectTimeoutError,
+            botocore.exceptions.EndpointConnectionError,
+            botocore.exceptions.ConnectionClosedError,
+        ),
+    ):
+        return True
+    if isinstance(exc, botocore.exceptions.ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in _THROTTLE_CODES:
+            return True
+        http_status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+        return http_status >= 500
+    return False
+
+
+def _backoff_s(attempt: int) -> float:
+    """Full-jitter exponential backoff capped at 2 seconds."""
+    ceiling: float = min(2.0, 0.1 * (2**attempt))
+    return random.random() * ceiling
+
+
+# -- Upload orchestration ----------------------------------------------------
+
+
+def _upload_blocks(
+    path: Path,
+    snapshot_id: str,
+    block_count: int,
+    file_size: int,
+    client: EBSClient,
+    workers: int,
+    block_attempts: int,
+) -> None:
+    """Upload all blocks in parallel with per-block retries."""
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        failed: dict[int, BaseException] = {}
+        failed_lock = threading.Lock()
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures: dict[Future[None], int] = {}
+            for idx in range(block_count):
+                with failed_lock:
+                    if failed:
+                        break
+                f = pool.submit(
+                    _upload_one_block,
+                    fd,
+                    snapshot_id,
+                    idx,
+                    file_size,
+                    client,
+                    block_attempts,
+                )
+                futures[f] = idx
+
+            for f in as_completed(futures):
+                exc = f.exception()
+                if exc is not None:
+                    with failed_lock:
+                        failed[futures[f]] = exc
+    finally:
+        os.close(fd)
+
+    if failed:
+        first_idx = min(failed)
+        raise RuntimeError(
+            f"{len(failed)} block(s) failed; "
+            f"first failure at block {first_idx}: {failed[first_idx]}"
+        )
+
+
+def _upload_one_block(
+    fd: int,
+    snapshot_id: str,
+    block_index: int,
+    file_size: int,
+    client: EBSClient,
+    block_attempts: int,
+) -> None:
+    """Upload a single block with retries and exponential backoff."""
+    data = _read_block(fd, block_index, file_size)
+
+    last_exc: Exception | None = None
+    for attempt in range(block_attempts):
+        if attempt > 0:
+            delay = _backoff_s(attempt)
+            log.debug(
+                "block %d: retry %d/%d, backoff %.0fms",
+                block_index,
+                attempt,
+                block_attempts,
+                delay * 1000,
+            )
+            time.sleep(delay)
+        try:
+            _put_block(client, snapshot_id, block_index, data)
+            return
+        except Exception as exc:
+            if not _is_retryable(exc):
+                raise RuntimeError(
+                    f"block {block_index}: permanent failure: {exc}"
+                ) from exc
+            last_exc = exc
+            log.warning(
+                "block %d: attempt %d/%d failed: %s",
+                block_index,
+                attempt + 1,
+                block_attempts,
+                exc,
+            )
+
+    raise RuntimeError(
+        f"block {block_index}: failed after {block_attempts} attempts: {last_exc}"
+    )

--- a/upload-ami/src/upload_ami/upload_ami.py
+++ b/upload-ami/src/upload_ami/upload_ami.py
@@ -1,21 +1,18 @@
-import json
 import hashlib
+import json
 import logging
 from pathlib import Path
 from typing import Iterable, Literal, TypedDict
 import boto3
-import boto3.ec2
-import boto3.ec2.createtags
-import botocore
-import botocore.exceptions
 import datetime
 
 from mypy_boto3_ec2.client import EC2Client
 from mypy_boto3_ec2.literals import BootModeValuesType
 from mypy_boto3_ec2.type_defs import RegionTypeDef, RegisterImageRequestTypeDef
-from mypy_boto3_s3.client import S3Client
 
 from concurrent.futures import ThreadPoolExecutor
+
+from .snapshot_uploader import upload_snapshot
 
 
 class ImageInfo(TypedDict):
@@ -26,100 +23,43 @@ class ImageInfo(TypedDict):
     format: str
 
 
-def upload_to_s3_if_not_exists(
-    s3: S3Client, bucket: str, image_name: str, file_path: Path
-) -> None:
-    """
-    Upload file to S3 if it doesn't exist yet
-
-    This function is idempotent.
-    """
-    try:
-        logging.info(f"Checking if s3://{bucket}/{image_name} exists")
-        s3.head_object(Bucket=bucket, Key=image_name)
-    except botocore.exceptions.ClientError:
-        logging.info(f"Uploading {file_path} to s3://{bucket}/{image_name}")
-        s3.upload_file(str(file_path), bucket, image_name)
-        s3.get_waiter("object_exists").wait(Bucket=bucket, Key=image_name)
-
-
 def import_snapshot_if_not_exist(
-    s3: S3Client,
     ec2: EC2Client,
-    s3_bucket: str,
     image_name: str,
     image_file: Path,
-    image_format: str,
-    import_role_name: str,
+    region: str,
 ) -> str:
     """
-    Import snapshot from S3 and wait for it to finish
+    Upload a raw disk image directly to an EBS snapshot.
 
-    This function is idempotent by using the image_name as the client token
-
-    Returns the snapshot id
+    Idempotent: returns the existing snapshot ID if one with the same
+    name tag already exists.
     """
-
     snapshots = ec2.describe_snapshots(
-        Filters=[{"Name": "tag:Name", "Values": [image_name]}]
+        OwnerIds=["self"],
+        Filters=[
+            {"Name": "tag:Name", "Values": [image_name]},
+            {"Name": "status", "Values": ["completed"]},
+        ],
     )
 
     if len(snapshots["Snapshots"]) != 0:
-        assert len(snapshots["Snapshots"]) == 1
-        assert "SnapshotId" in snapshots["Snapshots"][0]
-        snapshot_id = snapshots["Snapshots"][0]["SnapshotId"]
-    else:
-        upload_to_s3_if_not_exists(s3, s3_bucket, image_name, image_file)
+        if len(snapshots["Snapshots"]) != 1:
+            raise RuntimeError(
+                f"Expected 1 snapshot named {image_name!r}, "
+                f"found {len(snapshots['Snapshots'])}"
+            )
+        snapshot_id: str = snapshots["Snapshots"][0]["SnapshotId"]
+        return snapshot_id
 
-        logging.info(f"Importing s3://{s3_bucket}/{image_name} to EC2")
-        client_token_hash = hashlib.sha256(image_name.encode())
-        client_token = client_token_hash.hexdigest()
-        # TODO: I'm not sure how long AWS keeps track of import_snapshot_tasks and
-        # thus if we can rely on the client token forever. E.g. what happens if I
-        # run a task with the same client token a few months later?
-        snapshot_import_task = ec2.import_snapshot(
-            DiskContainer={
-                "Description": image_name,
-                "Format": image_format,
-                "UserBucket": {"S3Bucket": s3_bucket, "S3Key": image_name},
-            },
-            TagSpecifications=[
-                {
-                    "ResourceType": "import-snapshot-task",
-                    "Tags": [
-                        {"Key": "Name", "Value": image_name},
-                        {"Key": "ManagedBy", "Value": "NixOS/amis"},
-                    ],
-                }
-            ],
-            Description=image_name,
-            ClientToken=client_token,
-            RoleName=import_role_name,
-        )
-        ec2.get_waiter("snapshot_imported").wait(
-            ImportTaskIds=[snapshot_import_task["ImportTaskId"]],
-            WaiterConfig={
-                "Delay": 15,  # Same as the default for this waiter
-                "MaxAttempts": 400,  # Default is 40 (10min) 400 is 100 minutes
-            },
-        )
-
-        snapshot_import_tasks = ec2.describe_import_snapshot_tasks(
-            ImportTaskIds=[snapshot_import_task["ImportTaskId"]]
-        )
-        assert len(snapshot_import_tasks["ImportSnapshotTasks"]) != 0
-        snapshot_import_task_2 = snapshot_import_tasks["ImportSnapshotTasks"][0]
-        assert "SnapshotTaskDetail" in snapshot_import_task_2
-        assert "SnapshotId" in snapshot_import_task_2["SnapshotTaskDetail"]
-        snapshot_id = snapshot_import_task_2["SnapshotTaskDetail"]["SnapshotId"]
-        ec2.create_tags(
-            Resources=[snapshot_id],
-            Tags=[
-                {"Key": "Name", "Value": image_name},
-                {"Key": "ManagedBy", "Value": "NixOS/amis"},
-            ],
-        )
-    s3.delete_object(Bucket=s3_bucket, Key=image_name)
+    client_token = hashlib.sha256(image_name.encode()).hexdigest()
+    snapshot_id = upload_snapshot(
+        image_file,
+        region=region,
+        description=image_name,
+        tags={"Name": image_name, "ManagedBy": "NixOS/amis"},
+        client_token=client_token,
+    )
     return snapshot_id
 
 
@@ -316,14 +256,12 @@ def copy_image_to_regions(
 
 def upload_ami(
     image_info: ImageInfo,
-    s3_bucket: str,
     copy_to_regions: bool,
     prefix: str,
     run_id: str,
     public: bool,
     dest_regions: list[str],
     enable_tpm: bool,
-    import_role_name: str,
     best_effort_regions: list[str] = [],
 ) -> dict[str, str]:
     """
@@ -333,16 +271,14 @@ def upload_ami(
     """
 
     ec2: EC2Client = boto3.client("ec2")
-    s3: S3Client = boto3.client("s3")
 
     image_file = Path(image_info["file"])
     label = image_info["label"]
     system = image_info["system"]
     image_name = prefix + label + "-" + system + ("." + run_id if run_id else "")
 
-    image_format = image_info.get("format") or "VHD"
     snapshot_id = import_snapshot_if_not_exist(
-        s3, ec2, s3_bucket, image_name, image_file, image_format, import_role_name
+        ec2, image_name, image_file, ec2.meta.region_name
     )
 
     image_id = register_image_if_not_exists(
@@ -377,9 +313,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Upload NixOS AMI to AWS")
     parser.add_argument("--image-info", help="Path to image info", required=True)
-    parser.add_argument("--s3-bucket", help="S3 bucket to upload to", required=True)
     parser.add_argument("--debug", action="store_true")
-    parser.add_argument("--cleanup", action="store_true")
     parser.add_argument("--copy-to-regions", action="store_true")
     parser.add_argument("--public", action="store_true")
     parser.add_argument(
@@ -398,12 +332,6 @@ def main() -> None:
         default=False,
         help="Enable TPM 2.0 support for UEFI x86_64 images",
     )
-
-    parser.add_argument(
-        "--import-role-name",
-        default="vmimport",
-        help="Role to use to import snapshots from S3",
-    )
     parser.add_argument(
         "--best-effort-region",
         help="Regions where copy failures are logged as warnings instead of errors",
@@ -419,17 +347,14 @@ def main() -> None:
     with open(args.image_info, "r") as f:
         image_info = json.load(f)
 
-    image_ids = {}
     image_ids = upload_ami(
         image_info,
-        args.s3_bucket,
         args.copy_to_regions,
         args.prefix,
         args.run_id,
         args.public,
         args.dest_region,
         args.enable_tpm,
-        args.import_role_name,
         args.best_effort_region,
     )
     print(json.dumps(image_ids))


### PR DESCRIPTION
Fixes: https://github.com/NixOS/amis/issues/352

The old path (upload VHD to S3 → ec2.import_snapshot → poll up to 100 min) was slow, required extra infrastructure (S3 bucket, vmimport IAM role), and had fragile idempotency.

AWS's official tool for this is coldsnap, but it can sometimes hang indefinitely when running from outside EC2 (awslabs/coldsnap#437). This PR adds a small custom uploader using the EBS Direct APIs directly with explicit timeout/retry control. Once that issue is closed we can evaluate switching to coldsnap.

The new snapshot_uploader module writes 512 KiB blocks in parallel (64 workers, 8 sharded boto3 clients) with per-block checksums, retry with backoff, and automatic cleanup.

Changes:
- New: snapshot_uploader.py
- Rewrite: upload_ami.py (remove S3 path, add OwnerIds/status filters)
- Rename: upload-legacy-ami.yml -> upload-ami.yml, add VHD-to-raw step
- Terraform: add EBS Direct perms, remove S3/ImportSnapshot perms
- pyproject.toml: add ebs to boto3-stubs, remove s3