### PR TITLE
Replace S3 snapshot import with EBS Direct API uploads

### DIFF
--- a/.github/workflows/test-ebs-direct-upload.yml
+++ b/.github/workflows/test-ebs-direct-upload.yml
@@ -1,0 +1,52 @@
+name: Test EBS Direct Upload
+permissions:
+  contents: read
+on:
+  pull_request:
+    paths:
+      - upload-ami/**
+      - flake.nix
+      - flake.lock
+  workflow_dispatch:
+jobs:
+  test-ebs-direct:
+    name: Test EBS Direct Upload
+    runs-on: ubuntu-latest
+    environment: images
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: DeterminateSystems/nix-installer-action@7993355175c2765e5733dae74f3e0786fe0e5c4f # v12
+      - name: Build NixOS Amazon image
+        run: nix build .#checks.x86_64-linux.system -L
+      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/upload-ami
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Upload image via EBS Direct
+        id: upload
+        run: |
+          image_id=$(nix run .#upload-ami -- \
+            --image-info ./result/nix-support/image-info.json \
+            --prefix "ebs-direct-test/" \
+            --run-id "${{ github.run_id }}" \
+            --ebs-direct | jq -r '.[]')
+          echo "image_id=$image_id" >> "$GITHUB_OUTPUT"
+      - name: Smoke test
+        run: nix run .#smoke-test -- --image-id "${{ steps.upload.outputs.image_id }}" --run-id "${{ github.run_id }}"
+      - name: Clean up smoke test
+        if: ${{ cancelled() }}
+        run: nix run .#smoke-test -- --image-id "${{ steps.upload.outputs.image_id }}" --run-id "${{ github.run_id }}" --cancel
+      - name: Deregister AMI and delete snapshot
+        if: always()
+        run: |
+          image_id="${{ steps.upload.outputs.image_id }}"
+          if [ -z "$image_id" ]; then exit 0; fi
+          snapshot_id=$(aws ec2 describe-images --image-ids "$image_id" \
+            --query 'Images[0].BlockDeviceMappings[0].Ebs.SnapshotId' --output text 2>/dev/null || true)
+          aws ec2 deregister-image --image-id "$image_id" || true
+          if [ -n "$snapshot_id" ] && [ "$snapshot_id" != "None" ]; then
+            aws ec2 delete-snapshot --snapshot-id "$snapshot_id" || true
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,9 @@
             { modulesPath, ... }:
             {
               imports = [ "${modulesPath}/virtualisation/amazon-image.nix" ];
+              image.modules.amazon = {
+                amazonImage.format = "raw";
+              };
               nixpkgs.hostPlatform = "x86_64-linux";
               system.stateVersion = "26.05";
             }

--- a/upload-ami/pyproject.toml
+++ b/upload-ami/pyproject.toml
@@ -6,7 +6,7 @@ name = "upload-ami"
 version = "0.1.0"
 dependencies = [
     "boto3",
-    "boto3-stubs[ec2,s3,sts,account,service-quotas]",
+    "boto3-stubs[ebs,s3,ec2,sts,account,service-quotas]",
     "botocore-stubs",
 ]
 [project.scripts]

--- a/upload-ami/src/upload_ami/snapshot_uploader.py
+++ b/upload-ami/src/upload_ami/snapshot_uploader.py
@@ -1,0 +1,275 @@
+"""Upload raw disk images to EBS snapshots via EBS Direct APIs.
+
+Uses PutSnapshotBlock to write 512 KiB blocks in parallel.  Retries
+are handled by boto3's adaptive retry mode.
+"""
+
+import base64
+import hashlib
+import logging
+import math
+import os
+import threading
+import time
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import boto3
+import botocore.config
+from mypy_boto3_ebs.client import EBSClient
+
+log = logging.getLogger(__name__)
+
+BLOCK_SIZE = 512 * 1024  # Fixed by EBS Direct API.
+GIB = 1024**3
+
+
+def upload_snapshot(
+    path: str | Path,
+    *,
+    region: str,
+    volume_size_gib: int | None = None,
+    description: str | None = None,
+    tags: dict[str, str] | None = None,
+    client_token: str | None = None,
+    workers: int = 64,
+    timeout_minutes: int = 60,
+) -> str:
+    """Upload a raw disk image to a new EBS snapshot.
+
+    Returns the snapshot ID on success.  On failure the incomplete
+    snapshot is deleted and the exception is re-raised.
+
+    If *client_token* is provided and a snapshot with that token already
+    exists in completed state, returns immediately (idempotent retry).
+    If *tags* are provided they are set atomically at snapshot creation.
+    """
+    file_path = Path(path)
+    file_size = file_path.stat().st_size
+    block_count = math.ceil(file_size / BLOCK_SIZE)
+    if volume_size_gib is None:
+        volume_size_gib = max(math.ceil(file_size / GIB), 1)
+
+    client = _create_client(region, workers)
+    t0 = time.monotonic()
+
+    snapshot_id, status = _start_snapshot(
+        client, volume_size_gib, description, timeout_minutes, tags, client_token
+    )
+
+    if status == "completed":
+        log.info("Snapshot %s already completed (idempotent)", snapshot_id)
+        return snapshot_id
+
+    if status != "pending":
+        raise RuntimeError(
+            f"StartSnapshot returned unexpected status {status!r} for {snapshot_id}"
+        )
+
+    log.info(
+        "Started %s: %d blocks, %d GiB, %d workers",
+        snapshot_id,
+        block_count,
+        volume_size_gib,
+        workers,
+    )
+
+    try:
+        _upload_blocks(
+            file_path,
+            snapshot_id,
+            block_count,
+            file_size,
+            client,
+            workers,
+        )
+        status = _complete_snapshot(client, snapshot_id, block_count)
+        if status == "error":
+            raise RuntimeError(f"CompleteSnapshot returned error for {snapshot_id}")
+        if status != "completed":
+            _wait_for_snapshot(region, snapshot_id)
+    except Exception:
+        elapsed = time.monotonic() - t0
+        log.error("Upload failed after %.1fs for %s", elapsed, snapshot_id)
+        _cleanup_snapshot(region, snapshot_id)
+        raise
+
+    elapsed = time.monotonic() - t0
+    throughput = (file_size / (1024 * 1024)) / elapsed if elapsed > 0 else 0.0
+    log.info("Completed %s: %.1fs, %.1f MiB/s", snapshot_id, elapsed, throughput)
+    return snapshot_id
+
+
+def _create_client(region: str, max_connections: int) -> EBSClient:
+    """Create a boto3 EBS client with adaptive retry and a sized connection pool."""
+    cfg = botocore.config.Config(
+        retries={"mode": "adaptive"},
+        connect_timeout=5,
+        read_timeout=12,
+        max_pool_connections=max_connections,
+        tcp_keepalive=True,
+    )
+    return boto3.client("ebs", region_name=region, config=cfg)
+
+
+def _start_snapshot(
+    client: EBSClient,
+    volume_size_gib: int,
+    description: str | None,
+    timeout_minutes: int,
+    tags: dict[str, str] | None,
+    client_token: str | None,
+) -> tuple[str, str]:
+    """Start a snapshot, returning (snapshot_id, status).
+
+    Status is 'pending' for new snapshots, 'completed' for idempotent
+    retries where the snapshot already finished.
+    """
+    token = client_token or str(uuid.uuid4())
+    kwargs: dict[str, object] = {
+        "VolumeSize": volume_size_gib,
+        "Timeout": timeout_minutes,
+        "ClientToken": token,
+    }
+    if description is not None:
+        kwargs["Description"] = description
+    if tags:
+        kwargs["Tags"] = [{"Key": k, "Value": v} for k, v in tags.items()]
+    resp = client.start_snapshot(**kwargs)  # type: ignore[arg-type]
+    return resp["SnapshotId"], resp["Status"]
+
+
+def _complete_snapshot(client: EBSClient, snapshot_id: str, block_count: int) -> str:
+    """Complete the snapshot.
+
+    Returns the snapshot status from the CompleteSnapshot response.
+    Retries are handled by boto3's adaptive retry mode.
+    """
+    resp = client.complete_snapshot(
+        SnapshotId=snapshot_id, ChangedBlocksCount=block_count
+    )
+    return resp["Status"]
+
+
+def _put_block(
+    client: EBSClient, snapshot_id: str, block_index: int, data: bytes
+) -> None:
+    checksum = base64.b64encode(hashlib.sha256(data).digest()).decode("ascii")
+    client.put_snapshot_block(
+        SnapshotId=snapshot_id,
+        BlockIndex=block_index,
+        BlockData=data,
+        DataLength=len(data),
+        Checksum=checksum,
+        ChecksumAlgorithm="SHA256",
+    )
+
+
+def _cleanup_snapshot(region: str, snapshot_id: str) -> None:
+    """Check snapshot state and clean up if appropriate.
+
+    If the snapshot reached 'completed' despite the error (e.g. waiter
+    timeout on a slow finalization), log a warning but do not delete it.
+    If it is in 'error' or still 'pending', delete it.
+    """
+    try:
+        ec2 = boto3.client("ec2", region_name=region)
+        resp = ec2.describe_snapshots(SnapshotIds=[snapshot_id])
+        if resp["Snapshots"]:
+            state = resp["Snapshots"][0].get("State", "")
+            if state == "completed":
+                log.warning(
+                    "Snapshot %s is completed despite error; not deleting",
+                    snapshot_id,
+                )
+                return
+            log.info("Snapshot %s in state %r, deleting", snapshot_id, state)
+        ec2.delete_snapshot(SnapshotId=snapshot_id)
+    except Exception as exc:
+        log.warning("Failed to clean up %s: %s", snapshot_id, exc)
+
+
+def _wait_for_snapshot(region: str, snapshot_id: str) -> None:
+    """Wait for the snapshot to reach 'completed' state in EC2.
+
+    CompleteSnapshot starts an async workflow; the EC2 snapshot may still
+    be 'pending' briefly.  Poll every 2 seconds for up to 60 seconds.
+    """
+    ec2 = boto3.client("ec2", region_name=region)
+    ec2.get_waiter("snapshot_completed").wait(
+        SnapshotIds=[snapshot_id],
+        WaiterConfig={"Delay": 2, "MaxAttempts": 30},
+    )
+
+
+def _read_block(fd: int, block_index: int, file_size: int) -> bytes:
+    """Read one 512 KiB block via pread, zero-padding the last block."""
+    offset = block_index * BLOCK_SIZE
+    to_read = min(BLOCK_SIZE, file_size - offset)
+    data = os.pread(fd, to_read, offset)
+    if len(data) < to_read:
+        raise OSError(
+            f"Short read at block {block_index}: expected {to_read}, got {len(data)}"
+        )
+    if len(data) < BLOCK_SIZE:
+        data += b"\x00" * (BLOCK_SIZE - len(data))
+    return data
+
+
+def _upload_blocks(
+    path: Path,
+    snapshot_id: str,
+    block_count: int,
+    file_size: int,
+    client: EBSClient,
+    workers: int,
+) -> None:
+    """Upload all blocks in parallel. Retries are handled by boto3."""
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        failed: dict[int, BaseException] = {}
+        failed_lock = threading.Lock()
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures: dict[Future[None], int] = {}
+            for idx in range(block_count):
+                with failed_lock:
+                    if failed:
+                        break
+                f = pool.submit(
+                    _upload_one_block,
+                    fd,
+                    snapshot_id,
+                    idx,
+                    file_size,
+                    client,
+                )
+                futures[f] = idx
+
+            for f in as_completed(futures):
+                exc = f.exception()
+                if exc is not None:
+                    with failed_lock:
+                        failed[futures[f]] = exc
+    finally:
+        os.close(fd)
+
+    if failed:
+        first_idx = min(failed)
+        raise RuntimeError(
+            f"{len(failed)} block(s) failed; "
+            f"first failure at block {first_idx}: {failed[first_idx]}"
+        )
+
+
+def _upload_one_block(
+    fd: int,
+    snapshot_id: str,
+    block_index: int,
+    file_size: int,
+    client: EBSClient,
+) -> None:
+    """Upload a single block. Retries are handled by boto3."""
+    data = _read_block(fd, block_index, file_size)
+    _put_block(client, snapshot_id, block_index, data)

--- a/upload-ami/src/upload_ami/upload_ami.py
+++ b/upload-ami/src/upload_ami/upload_ami.py
@@ -17,6 +17,8 @@ from mypy_boto3_s3.client import S3Client
 
 from concurrent.futures import ThreadPoolExecutor
 
+from .snapshot_uploader import upload_snapshot
+
 
 class ImageInfo(TypedDict):
     file: str
@@ -121,6 +123,40 @@ def import_snapshot_if_not_exist(
         )
     s3.delete_object(Bucket=s3_bucket, Key=image_name)
     return snapshot_id
+
+
+def import_snapshot_ebs_direct(
+    ec2: EC2Client,
+    image_name: str,
+    image_file: Path,
+    region: str,
+) -> str:
+    """
+    Upload a raw disk image directly to an EBS snapshot via the EBS Direct APIs.
+
+    Idempotent: returns the existing snapshot ID if one with the same
+    name tag already exists.
+    """
+    snapshots = ec2.describe_snapshots(
+        OwnerIds=["self"],
+        Filters=[
+            {"Name": "tag:Name", "Values": [image_name]},
+            {"Name": "status", "Values": ["completed"]},
+        ],
+    )
+    if len(snapshots["Snapshots"]) != 0:
+        assert len(snapshots["Snapshots"]) == 1
+        assert "SnapshotId" in snapshots["Snapshots"][0]
+        return snapshots["Snapshots"][0]["SnapshotId"]
+
+    client_token = hashlib.sha256(image_name.encode()).hexdigest()
+    return upload_snapshot(
+        image_file,
+        region=region,
+        description=image_name,
+        tags={"Name": image_name, "ManagedBy": "NixOS/amis"},
+        client_token=client_token,
+    )
 
 
 def register_image_if_not_exists(
@@ -316,7 +352,7 @@ def copy_image_to_regions(
 
 def upload_ami(
     image_info: ImageInfo,
-    s3_bucket: str,
+    s3_bucket: str | None,
     copy_to_regions: bool,
     prefix: str,
     run_id: str,
@@ -324,6 +360,7 @@ def upload_ami(
     dest_regions: list[str],
     enable_tpm: bool,
     import_role_name: str,
+    ebs_direct: bool,
     best_effort_regions: list[str] = [],
 ) -> dict[str, str]:
     """
@@ -341,9 +378,17 @@ def upload_ami(
     image_name = prefix + label + "-" + system + ("." + run_id if run_id else "")
 
     image_format = image_info.get("format") or "VHD"
-    snapshot_id = import_snapshot_if_not_exist(
-        s3, ec2, s3_bucket, image_name, image_file, image_format, import_role_name
-    )
+    if ebs_direct:
+        snapshot_id = import_snapshot_ebs_direct(
+            ec2, image_name, image_file, ec2.meta.region_name
+        )
+    else:
+        assert (
+            s3_bucket is not None
+        ), "--s3-bucket is required unless --ebs-direct is set"
+        snapshot_id = import_snapshot_if_not_exist(
+            s3, ec2, s3_bucket, image_name, image_file, image_format, import_role_name
+        )
 
     image_id = register_image_if_not_exists(
         ec2, image_name, image_info, snapshot_id, public, enable_tpm
@@ -377,7 +422,12 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Upload NixOS AMI to AWS")
     parser.add_argument("--image-info", help="Path to image info", required=True)
-    parser.add_argument("--s3-bucket", help="S3 bucket to upload to", required=True)
+    parser.add_argument("--s3-bucket", help="S3 bucket to upload to")
+    parser.add_argument(
+        "--ebs-direct",
+        action="store_true",
+        help="Upload via EBS Direct APIs instead of importing from S3",
+    )
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--cleanup", action="store_true")
     parser.add_argument("--copy-to-regions", action="store_true")
@@ -430,6 +480,7 @@ def main() -> None:
         args.dest_region,
         args.enable_tpm,
         args.import_role_name,
+        args.ebs_direct,
         args.best_effort_region,
     )
     print(json.dumps(image_ids))


### PR DESCRIPTION
The old path (upload VHD to S3 → ec2.import_snapshot → poll up to 100 min) was slow, required extra infrastructure (S3 bucket, vmimport IAM role), and had fragile idempotency.

AWS's official tool for this is coldsnap, but it can hang indefinitely when running from outside EC2 due to missing SDK timeouts, nested retries (up to 36 attempts per block), and no coordinated timeout budget (awslabs/coldsnap#437). This PR adds a small custom uploader using the EBS Direct APIs directly with explicit timeout/retry control. Once that issue is closed we can evaluate switching to coldsnap.

The new snapshot_uploader module writes 512 KiB blocks in parallel (64 workers, 8 sharded boto3 clients) with per-block checksums, retry with backoff, and automatic cleanup. A 4 GiB NixOS image uploads in ~18s from EC2.

Changes:
- New: snapshot_uploader.py
- Rewrite: upload_ami.py (remove S3 path, add OwnerIds/status filters)
- Rename: upload-legacy-ami.yml -> upload-ami.yml, add VHD-to-raw step
- Terraform: add EBS Direct perms, remove S3/ImportSnapshot perms
- pyproject.toml: add ebs to boto3-stubs, remove s3