### PR TITLE
Remove 25.05 from upload matrix

### DIFF
--- a/.github/workflows/upload-legacy-ami.yml
+++ b/.github/workflows/upload-legacy-ami.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         release:
-          - release-25.05
           - release-25.11
           # - nixos-unstable
         system:


### PR DESCRIPTION
NixOS 25.05 has reached end of life and we aren't building it anymore, lets stop uploading it.