### PR TITLE
Drop explicit amazon-image.nix import

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,19 @@ Yes! for example with a config like this:
 {
   inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
-  outputs = { nixpkgs, ... }: {
-    nixosConfigurations.my-system = nixpkgs.lib.nixosSystem {
-      modules = [
-        { modulesPath, ... }:
-          imports = [ "${modulesPath}/virtualisation/amazon-image.nix" ];
-          virtualisation.diskSize = "auto";  # or gigabytes. default is 3 * 1024
-          nixpkgs.hostPlatform = "x86_64-linux";
-          services.nginx.enable = true;
-        }
-      ];
+  outputs =
+    { nixpkgs, ... }:
+    {
+      nixosConfigurations.my-system = nixpkgs.lib.nixosSystem {
+        modules = [
+          {
+            virtualisation.diskSize = "auto"; # or gigabytes. default is 3 * 1024
+            nixpkgs.hostPlatform = "x86_64-linux";
+            services.nginx.enable = true;
+          }
+        ];
+      };
     };
-  };
 }
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,17 +70,13 @@
       # NOTE: Github Actions doesn't support kvm on arm64 builds
       nixosConfigurations.x86_64-linux = nixpkgs.lib.nixosSystem {
         modules = [
-          (
-            { modulesPath, ... }:
-            {
-              imports = [ "${modulesPath}/virtualisation/amazon-image.nix" ];
-              image.modules.amazon = {
-                amazonImage.format = "raw";
-              };
-              nixpkgs.hostPlatform = "x86_64-linux";
-              system.stateVersion = "26.05";
-            }
-          )
+          {
+            image.modules.amazon = {
+              amazonImage.format = "raw";
+            };
+            nixpkgs.hostPlatform = "x86_64-linux";
+            system.stateVersion = "26.05";
+          }
         ];
       };
 


### PR DESCRIPTION
`system.build.images.amazon` now pulls in the amazon image module on
the side via extendModules, there is no need to import `virtualisation/amazon-image.nix` into top-level configuration.
