### PR TITLE
Add release-26.05 to upload matrix

### DIFF
--- a/.github/workflows/upload-legacy-ami.yml
+++ b/.github/workflows/upload-legacy-ami.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         release:
           - release-25.11
+          - release-26.05
           # - nixos-unstable
         system:
           - x86_64-linux


### PR DESCRIPTION
According to my [release manager checklist].

[release manager checklist]: https://nixos.github.io/release-wiki/Branch-Off.html#once-the-channel-is-available